### PR TITLE
Search problems #28

### DIFF
--- a/src/main/webapp/js/search.js
+++ b/src/main/webapp/js/search.js
@@ -504,8 +504,9 @@ function wildcardMatch(text, searchText) {
 		if (pos[i] < 0) return false;
 		if (atStart && atEnd && !interiorMatch(text, parts[i])) return false;
 		if (i > 0) {
-			pos[i] = text.indexOf(parts[i], pos[i - 1]);
-			if (pos[i] < 0) return false;
+            var offset = (pos[i - 1] || 0) + parts[i - 1].length;
+            pos[i] = text.indexOf(parts[i], offset);
+            if (pos[i] < 0) return false;
 		}
 	}
 	return true;


### PR DESCRIPTION
“*th*th” matches words only ending in “th”

Updated wildcardMatch to calculate the correct offset for subsequent searches. The indexOf check for the current part now starts at pos[i - 1] + parts[i - 1].length (the end of the previous match).